### PR TITLE
add securetmp as a require for php-fpm

### DIFF
--- a/SOURCES/php-fpm.service
+++ b/SOURCES/php-fpm.service
@@ -5,7 +5,7 @@
 
 [Unit]
 Description=The PHP FastCGI Process Manager
-After=syslog.target network.target
+After=syslog.target network.target securetmp.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
- PHP-FPM is failing to start at bootup time because it cannot create it's lock file in /tmp
- /tmp is not yet available on some servers as it's run by securetmp on some servers
- adds securetmp.service as a requirement to php-fpm.service
- change is made for PHP 7.0 only, similar - changes should probably be made for PHP 5.6, 5.5, and 5.4

I've opened cPanel ticket 8844361 for this - I'm guessing that'll result in a case # too.